### PR TITLE
use POST instead of GET to send a message and put the text in the request body

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,6 +30,7 @@ func (sl *Slack) GetRequest(endpoint string, uv *url.Values) ([]byte, error) {
 func (sl *Slack) PostRequest(endpoint string, uv *url.Values, body *bytes.Buffer) ([]byte, error) {
 	ul := apiBaseUrl + endpoint
 	req, err := http.NewRequest("POST", ul, body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		return nil, err
 	}

--- a/chat.go
+++ b/chat.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/url"
@@ -13,9 +14,8 @@ func (sl *Slack) ChatPostMessage(channelId string, text string, opt *ChatPostMes
 		return err
 	}
 	uv.Add("channel", channelId)
-	uv.Add("text", text)
 
-	body, err := sl.GetRequest(chatPostMessageApiEndpoint, uv)
+	body, err := sl.PostRequest(chatPostMessageApiEndpoint, uv, sl.buildRequestBodyForm(text))
 	if err != nil {
 		return err
 	}
@@ -48,6 +48,10 @@ type ChatPostMessageAPIResponse struct {
 	BaseAPIResponse
 	Channel string `json:"channel"`
 	Ts      string `json:"ts"`
+}
+
+func (sl *Slack) buildRequestBodyForm(text string) (*bytes.Buffer) {
+    return bytes.NewBuffer([]byte("text=" + text))
 }
 
 func (sl *Slack) buildChatPostMessageUrlValues(opt *ChatPostMessageOpt) (*url.Values, error) {


### PR DESCRIPTION
I noticed that sending long messages resulted in weird error messages in slackcat. The root cause was that the GET request from ChatPostMessage received a `HTTP Error 414 Request URI too long` response, which caused the json parsing of the response to fail.

This code uses the already existing PostRequest and sends the text in the body.

The Slack API doesn't support json bodies yet, hence the supported x-www-form-urlencoded content-type.
