### PR TITLE
Add support for "ChannelsInfo" and "ChannelsMark"

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -86,7 +86,7 @@ type ChannelsInfoAPIResponse struct {
 
 func (sl *Slack) ChannelsInfo(id string) (*Channel, error) {
 	uv := sl.urlValues()
-	uv.Add("name", id)
+	uv.Add("channel", id)
 	body, err := sl.GetRequest(channelsInfoApiEndpoint, uv)
 	if err != nil {
 		return nil, err

--- a/channels.go
+++ b/channels.go
@@ -78,6 +78,30 @@ func (ch *Channel) Purpose() (*Purpose, error) {
 	return pp, nil
 }
 
+// response type for `channels.list` api
+type ChannelsInfoAPIResponse struct {
+	BaseAPIResponse
+	Channel Channel
+}
+
+func (sl *Slack) ChannelsInfo(id string) (*Channel, error) {
+	uv := sl.urlValues()
+	uv.Add("name", id)
+	body, err := sl.GetRequest(channelsInfoApiEndpoint, uv)
+	if err != nil {
+		return nil, err
+	}
+	res := new(ChannelsInfoAPIResponse)
+	err = json.Unmarshal(body, res)
+	if err != nil {
+		return nil, err
+	}
+	if !res.Ok {
+		return nil, errors.New(res.Error)
+	}
+	return &res.Channel, nil
+}
+
 // FindChannel returns a channel object that satisfy conditions specified.
 func (sl *Slack) FindChannel(cb func(*Channel) bool) (*Channel, error) {
 	channels, err := sl.ChannelsList()
@@ -126,7 +150,7 @@ func (sl *Slack) JoinChannel(name string) error {
 
 type Message struct {
 	Type    string `json:"type"`
-	Subtype string `json:",omitempty"`
+	Subtype string `json:"subtype"`
 	Ts      string `json:"ts"`
 	UserId  string `json:"user"`
 	Text    string `json:"text"`

--- a/channels.go
+++ b/channels.go
@@ -46,7 +46,7 @@ type Channel struct {
 	RawTopic    json.RawMessage `json:"topic"`
 	RawPurpose  json.RawMessage `json:"purpose"`
 	NumMembers  int             `json:"num_members"`
-	LastRead    float64         `json:"last_read,omitempty"`
+	LastRead    string          `json:"last_read,omitempty"`
 	UnreadCount float64         `json:"unread_count,omitempty"`
 }
 

--- a/channels.go
+++ b/channels.go
@@ -34,18 +34,20 @@ type ChannelsListAPIResponse struct {
 
 // slack channel type
 type Channel struct {
-	Id         string          `json:"id"`
-	Name       string          `json:"name"`
-	IsChannel  bool            `json:"is_channel"`
-	Created    int             `json:"created"`
-	Creator    string          `json:"creator"`
-	IsArchived bool            `json:"is_archived"`
-	IsGeneral  bool            `json:"is_general"`
-	IsMember   bool            `json:"is_member"`
-	Members    []string        `json:"members"`
-	RawTopic   json.RawMessage `json:"topic"`
-	RawPurpose json.RawMessage `json:"purpose"`
-	NumMembers int             `json:"num_members"`
+	Id          string          `json:"id"`
+	Name        string          `json:"name"`
+	IsChannel   bool            `json:"is_channel"`
+	Created     int             `json:"created"`
+	Creator     string          `json:"creator"`
+	IsArchived  bool            `json:"is_archived"`
+	IsGeneral   bool            `json:"is_general"`
+	IsMember    bool            `json:"is_member"`
+	Members     []string        `json:"members"`
+	RawTopic    json.RawMessage `json:"topic"`
+	RawPurpose  json.RawMessage `json:"purpose"`
+	NumMembers  int             `json:"num_members"`
+	LastRead    float64         `json:"last_read,omitempty"`
+	UnreadCount float64         `json:"last_read,omitempty"`
 }
 
 // Channels returns a slice of channel object from a response of `channels.list` api.
@@ -97,6 +99,19 @@ func (sl *Slack) FindChannelByName(name string) (*Channel, error) {
 	})
 }
 
+// ChannelsMark moves the read cursor for the chosen channel.
+func (sl *Slack) ChannelsMark(name, ts string) error {
+	uv := sl.urlValues()
+	uv.Add("name", name)
+	uv.Add("ts", ts)
+
+	_, err := sl.GetRequest(channelsMarkApiEndpoint, uv)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // API channels.join: Joins a channel, creating it if needed.
 func (sl *Slack) JoinChannel(name string) error {
 	uv := sl.urlValues()
@@ -110,10 +125,11 @@ func (sl *Slack) JoinChannel(name string) error {
 }
 
 type Message struct {
-	Type   string `json:"type"`
-	Ts     string `json:"ts"`
-	UserId string `json:"user"`
-	Text   string `json:"text"`
+	Type    string `json:"type"`
+	Subtype string `json:",omitempty"`
+	Ts      string `json:"ts"`
+	UserId  string `json:"user"`
+	Text    string `json:"text"`
 }
 
 func (msg *Message) Timestamp() *time.Time {

--- a/channels.go
+++ b/channels.go
@@ -47,7 +47,7 @@ type Channel struct {
 	RawPurpose  json.RawMessage `json:"purpose"`
 	NumMembers  int             `json:"num_members"`
 	LastRead    float64         `json:"last_read,omitempty"`
-	UnreadCount float64         `json:"last_read,omitempty"`
+	UnreadCount float64         `json:"unread_count,omitempty"`
 }
 
 // Channels returns a slice of channel object from a response of `channels.list` api.

--- a/channels.go
+++ b/channels.go
@@ -126,7 +126,7 @@ func (sl *Slack) FindChannelByName(name string) (*Channel, error) {
 // ChannelsMark moves the read cursor for the chosen channel.
 func (sl *Slack) ChannelsMark(name, ts string) error {
 	uv := sl.urlValues()
-	uv.Add("name", name)
+	uv.Add("channel", name)
 	uv.Add("ts", ts)
 
 	_, err := sl.GetRequest(channelsMarkApiEndpoint, uv)

--- a/endpoints.go
+++ b/endpoints.go
@@ -3,6 +3,7 @@ package slack
 const (
 	apiBaseUrl = "https://slack.com/api/"
 
+	channelsInfoApiEndpoint    = "channels.info"
 	channelsListApiEndpoint    = "channels.list"
 	channelsJoinApiEndpoint    = "channels.join"
 	channelsHistoryApiEndpoint = "channels.history"

--- a/endpoints.go
+++ b/endpoints.go
@@ -6,6 +6,7 @@ const (
 	channelsListApiEndpoint    = "channels.list"
 	channelsJoinApiEndpoint    = "channels.join"
 	channelsHistoryApiEndpoint = "channels.history"
+	channelsMarkApiEndpoint    = "channels.mark"
 
 	chatPostMessageApiEndpoint = "chat.postMessage"
 


### PR DESCRIPTION
This commit adds support for the aforementioned API calls. It also adds member to the Channel and Message structs to better match the full slack API.
