### PR TITLE
Remove FindChannelByName from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,7 @@ const (
 
 func main() {
   api := slack.New(token)
-  channel, err := api.FindChannelByName(channelName)
-  if err != nil {
-    panic(err)
-  }
-  err = api.ChatPostMessage(channel.Id, "Hello, world!", nil)
+  err := api.ChatPostMessage(channelName, "Hello, world!", nil)
   if err != nil {
     panic(err)
   }

--- a/examples/chat_post_message.go
+++ b/examples/chat_post_message.go
@@ -11,11 +11,7 @@ const (
 
 func main() {
 	api := slack.New(token)
-	channel, err := api.FindChannelByName(channelName)
-	if err != nil {
-		panic(err)
-	}
-	err = api.ChatPostMessage(channel.Id, "Hello, world!", nil)
+	err := api.ChatPostMessage(channelName, "Hello, world!", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/post_group_message.go
+++ b/examples/post_group_message.go
@@ -12,12 +12,7 @@ const (
 
 func main() {
 	api := slack.New(token)
-	group, err := api.FindGroupByName(groupName)
-	if err != nil {
-		panic(err)
-	}
-
-	err = api.ChatPostMessage(group.Id, "Hello, world!", &slack.ChatPostMessageOpt{AsUser: true})
+	err := api.ChatPostMessage(groupName, "Hello, world!", &slack.ChatPostMessageOpt{AsUser: true})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The [chat.postMessage](https://api.slack.com/methods/chat.postMessage#channels) API accepts a public, private, or IM channel name without first resolving it to an ID, so this patch updates the examples to do that. The error message returned for non-existant channels is now slightly less helpful, but still pretty clear.

My reason for submitting this is that I didn't know that "channels" and "groups" were distinct, at first, so struggled to understand why posting messages to my private test channel wasn't working.
