### PR TITLE
Add footer fields to Attachment

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -25,6 +25,9 @@ type Attachment struct {
 	ImageURL string `json:"image_url,omitempty"`
 	ThumbURL string `json:"thumb_url,omitempty"`
 
+	Footer     string `json:"footer,omitempty"`
+	FooterIcon string `json:"footer_icon,omitempty"`
+
 	Fields     []*AttachmentField `json:"fields,omitempty"`
 	MarkdownIn []string           `json:"mrkdwn_in,omitempty"`
 }


### PR DESCRIPTION
Adding the struct fields to set the footer fields in the attachment payload.
