### PR TITLE
Add Subtype to the Message struct. 

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -110,10 +110,11 @@ func (sl *Slack) JoinChannel(name string) error {
 }
 
 type Message struct {
-	Type   string `json:"type"`
-	Ts     string `json:"ts"`
-	UserId string `json:"user"`
-	Text   string `json:"text"`
+	Type    string `json:"type"`
+	Ts      string `json:"ts"`
+	UserId  string `json:"user"`
+	Text    string `json:"text"`
+	Subtype string `json:"subtype"`
 }
 
 func (msg *Message) Timestamp() *time.Time {


### PR DESCRIPTION
Rationale: there are more than 20 different message subtypes (https://api.slack.com/events/message). Introducing this field makes filtering possible; for instance, one can filter simple messages with msg.Subtype == "".
