### PR TITLE
Make Message.Timestamp() more precise.

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -117,8 +117,9 @@ type Message struct {
 }
 
 func (msg *Message) Timestamp() *time.Time {
-	tsf, _ := strconv.ParseFloat(msg.Ts, 64)
-	ts := time.Unix(int64(tsf), 0)
+	seconds, _ := strconv.ParseInt(msg.Ts[0:10], 10, 64)
+	microseconds, _ := strconv.ParseInt(msg.Ts[11:17], 10, 64)
+	ts := time.Unix(seconds, microseconds*1e3)
 	return &ts
 }
 

--- a/channels_test.go
+++ b/channels_test.go
@@ -1,0 +1,16 @@
+package slack
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestMessageTimestamp(t *testing.T) {
+	ts := time.Date(2012, 11, 6, 10, 23, 42, 123456000, time.UTC)
+	var msg Message
+	msg.Ts = fmt.Sprintf("%d.%s", ts.Unix(), "123456")
+	if msg.Timestamp().UnixNano() != ts.UnixNano() {
+		t.Errorf("%v != %v", ts, msg.Timestamp())
+	}
+}


### PR DESCRIPTION
This change makes Message.Timestamp() return time microseconds-equivalent to the Message.Ts string representation.
