### PR TITLE
Turn http-client into singleton

### DIFF
--- a/api.go
+++ b/api.go
@@ -7,9 +7,14 @@ import (
 	"net/url"
 )
 
+var httpClient *http.Client
+
+func init() {
+	httpClient = &http.Client{}
+}
+
 func (sl *Slack) request(req *http.Request) ([]byte, error) {
-	cl := newHttpClient()
-	res, err := cl.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -40,8 +45,4 @@ func (sl *Slack) PostRequest(endpoint string, uv *url.Values, body *bytes.Buffer
 
 func (sl *Slack) DoRequest(req *http.Request) ([]byte, error) {
 	return sl.request(req)
-}
-
-func newHttpClient() *http.Client {
-	return &http.Client{}
 }


### PR DESCRIPTION
According to https://golang.org/pkg/net/http/, "Clients and Transports are safe for concurrent use by multiple goroutines and for efficiency should only be created once and re-used".
