### PR TITLE
Add unix timestamp field to Attachment struct

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -27,6 +27,7 @@ type Attachment struct {
 
 	Footer     string `json:"footer,omitempty"`
 	FooterIcon string `json:"footer_icon,omitempty"`
+	TimeStamp  int64  `json:"ts,omitempty"`
 
 	Fields     []*AttachmentField `json:"fields,omitempty"`
 	MarkdownIn []string           `json:"mrkdwn_in,omitempty"`


### PR DESCRIPTION
By providing the ts field with an integer value in "epoch time", the attachment will display an additional timestamp value as part of the attachment's footer.  -https://api.slack.com/docs/message-attachments