### PR TITLE
Add link_names to parameters for webhook

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -19,6 +19,7 @@ type WebHookPostPayload struct {
 	IconUrl     string        `json:"icon_url,omitempty"`
 	IconEmoji   string        `json:"icon_emoji,omitempty"`
 	UnfurlLinks bool          `json:"unfurl_links,omitempty"`
+	LinkNames   string        `json:"link_names,omitempty"`
 	Attachments []*Attachment `json:"attachments,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #27 

As mentioned in the above GitHub issue added support for `link_names`.