### PR TITLE
Add support for responses (and delayed responses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Golang client for the Slack API. Include the example code using each slack api.
 
 ## Currently supports:
 
+### API
+
 Method | Description | Example
 --- | --- | ---
 channels.history | Fetches history of messages and events from a channel. | [#link](https://github.com/bluele/slack/blob/master/examples/channels_history.go)
@@ -17,6 +19,18 @@ groups.create | Creates a private group. | [#link](https://github.com/bluele/sla
 groups.list | Lists private groups that the calling user has access to. | [#link](https://github.com/bluele/slack/blob/master/examples/groups_list.go)
 users.info | Gets information about a channel. | [#link](https://github.com/bluele/slack/blob/master/examples/users_info.go)
 users.list | Lists all users in a Slack team. | [#link](https://github.com/bluele/slack/blob/master/examples/users_list.go)
+
+### Webhooks
+
+Method | Description | Example
+--- | --- | ---
+hook.PostMessage | Post message to a slack webhook. | [#link](https://github.com/bluele/slack/blob/master/examples/webhook_post.go)
+
+### Slash command responses
+
+Method | Description | Example
+--- | --- | ---
+response.PostDelayedResponse | Post reply to a slack response url. | [#link](https://github.com/bluele/slack/blob/master/examples/delayed_response_post.go)
 
 
 ## Example

--- a/examples/delayed_response_post.go
+++ b/examples/delayed_response_post.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/bluele/slack"
+)
+
+// Please change these values to suit your environment
+const (
+	responseURL = "https://hooks.slack.com/services/xxxxxx/xxxxxx/xxxxxxxxxxxxxx"
+)
+
+func main() {
+	response := slack.NewDelayedResponse(responseURL)
+	err := response.PostDelayedResponse(&slack.ResponsePayload{
+		Text: "hello!",
+    ResponseType: "in_channel",
+		Attachments: []*slack.Attachment{
+			{Text: "danger", Color: "danger"},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+

--- a/response.go
+++ b/response.go
@@ -1,0 +1,48 @@
+package slack
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+)
+
+type DelayedResponse struct {
+	responseURL string
+}
+
+type ResponsePayload struct {
+	ResponseType string        `json:"response_type,omitempty"`
+	Text         string        `json:"text,omitempty"`
+	UnfurlLinks  bool          `json:"unfurl_links,omitempty"`
+	LinkNames    string        `json:"link_names,omitempty"`
+	Attachments  []*Attachment `json:"attachments,omitempty"`
+}
+
+func NewDelayedResponse(responseURL string) *DelayedResponse {
+	return &DelayedResponse{responseURL}
+}
+
+func (dr *DelayedResponse) PostDelayedResponse(payload *ResponsePayload) error {
+	//Slack recommends declaring this even if you wish to use the default "ephemeral" value
+	if payload.ResponseType == "" {
+		payload.ResponseType = "ephemeral"
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(dr.responseURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t, _ := ioutil.ReadAll(resp.Body)
+		return errors.New(string(t))
+	}
+
+	return nil
+}


### PR DESCRIPTION
* Adds support for slash command response payloads, and posting them to a delayed response url
* Adds example for posting a delayed response
* Updates README to include this new method, and the webhook post command too