### PR TITLE
webhook: treat all 2xx http status codes as success

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -38,7 +38,7 @@ func (hk *WebHook) PostMessage(payload *WebHookPostPayload) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		t, _ := ioutil.ReadAll(resp.Body)
 		return errors.New(string(t))
 	}


### PR DESCRIPTION
In HTTP by definition all status codes in 200 indicate success:
https://www.w3.org/Protocols/HTTP/HTRESP.html

Only return an error for status codes outside of 200-299.