### PR TITLE
Fix deprecated route to channels.list

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -5,7 +5,7 @@ const (
 
 	authTestApiEndpoint = "auth.test"
 
-	channelsListApiEndpoint    = "channels.list"
+	channelsListApiEndpoint    = "conversations.list"
 	channelsJoinApiEndpoint    = "channels.join"
 	channelsHistoryApiEndpoint = "channels.history"
 


### PR DESCRIPTION
### Motivation
The route "channels.list" was deprecated and does not work more.

### Solution
Adjust to use the new route "conversations.list"

### Ref.
[Slack Doc](https://api.slack.com/methods/channels.list)